### PR TITLE
Add MacOS deployment target to fix libc++ error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,8 @@
         "conditions": [
             ["OS == 'mac'", {
                 "xcode_settings": {
-                    "CLANG_CXX_LIBRARY": "libc++"
+                    "CLANG_CXX_LIBRARY": "libc++",
+                    "MACOSX_DEPLOYMENT_TARGET": "10.7",
                 }
             }]
         ]


### PR DESCRIPTION
Hi all,

Not sure if you're open to outside contributions, but I was trying to npm install the mapbox carmen repo and ran into the following error when it tried to install this as a dependency: 

```
> es6-native-map@4.0.2 install ...
> node-gyp configure build

gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR

  CXX(target) Release/obj.target/native/src/map.o
clang: error: invalid deployment target for -stdlib=libc++ (requires OS X 10.7 or later)
make: *** [Release/obj.target/native/src/map.o] Error 1
```
It looks like the OSX version needs to be specified (see [this stackoverflow discussion](https://stackoverflow.com/questions/21752172/invalid-deployment-target-for-stdlib-libc-on-osx-10-8))

This fixed it for me so I thought I'd share!

Same for node-native-set, I also made a [PR there](https://github.com/mapbox/node-native-set/pullshttps://github.com/mapbox/node-native-set/pull/3).


